### PR TITLE
masterブランチへのPR作成時のgithub actionsを作成

### DIFF
--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -1,13 +1,9 @@
 name: github actions on pull-request to master
 
 on:
-    # pull_request:
-    #     branches:
-    #         - "master"
-    # テスト用に、このブランチへのpushで起動
-    push:
+    pull_request:
         branches:
-            - "features/master-pr-github-actions"
+            - "master"
 
 jobs:
     chrome-extension-build:

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -1,0 +1,30 @@
+name: github actions on pull-request to master
+
+on:
+    # pull_request:
+    #     branches:
+    #         - "master"
+    # テスト用に、このブランチへのpushで起動
+    push:
+        branches:
+            - "features/master-pr-github-actions"
+
+jobs:
+    chrome-extension-build:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: ./chrome-extension
+        steps:
+            - name: "Checkout"
+              uses: actions/checkout@v3
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "21"
+
+            - name: Install dependencies and build
+              run: |
+                  npm install
+                  npm run build

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -5,6 +5,10 @@ on:
         branches:
             - "master"
 
+permissions:
+    contents: read
+    pull-requests: write
+
 jobs:
     chrome-extension-build:
         outputs:

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -11,6 +11,8 @@ on:
 
 jobs:
     chrome-extension-build:
+        outputs:
+            is-success: ${{steps.install-dependencies-and-build.outcome}} # 'success' or 'failure'
         runs-on: ubuntu-latest
         defaults:
             run:
@@ -25,6 +27,7 @@ jobs:
                   node-version: "21"
 
             - name: Install dependencies and build
+              id: install-dependencies-and-build
               run: |
                   npm install
                   npm run build

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -40,22 +40,24 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
-            - name: "Add Success Comment To PR"
+            - name: "Create Comment Body File For Success"
               if: needs.chrome-extension-build.outputs.is-success == 'success'
               run: |
                   cat << EOF > pr_comment.md
                   ## PR Test Pipeline Success
                   Github Actions Log: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
                   EOF
-                  gh pr comment --body-file pr_comment.md "${{github.event.pull_request.html_url}}"
-                  echo "PR Test Pipeline Success"
 
-            - name: "Add Failure Comment To PR"
+            - name: "Create Comment Body File For Failure"
               if: needs.chrome-extension-build.outputs.is-success == 'failure'
               run: |
                   cat << EOF > pr_comment.md
                   ## PR Test Pipeline Failed
                   Github Actions Log: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
                   EOF
+
+            - name: "Add Comment To PR"
+              if: always()
+              run: |
+                  cat pr_comment.md
                   gh pr comment --body-file pr_comment.md "${{github.event.pull_request.html_url}}"
-                  echo "PR Test Pipeline Failed"

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -47,7 +47,7 @@ jobs:
                   ## PR Test Pipeline Success
                   Github Actions Log: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
                   EOF
-                  gh pr comment ${{github.event.pull_request.number}} --body-file pr_comment.md
+                  gh pr comment --body-file pr_comment.md "${{github.event.pull_request.html_url}}"
                   echo "PR Test Pipeline Success"
 
             - name: "Add Failure Comment To PR"
@@ -57,5 +57,5 @@ jobs:
                   ## PR Test Pipeline Failed
                   Github Actions Log: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
                   EOF
-                  gh pr comment ${{github.event.pull_request.number}} --body-file pr_comment.md
+                  gh pr comment --body-file pr_comment.md "${{github.event.pull_request.html_url}}"
                   echo "PR Test Pipeline Failed"

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -28,3 +28,29 @@ jobs:
               run: |
                   npm install
                   npm run build
+
+    add-comment-to-pr:
+        runs-on: ubuntu-latest
+        needs:
+            - chrome-extension-build
+        if: always()
+        steps:
+            - name: "Add Success Comment To PR"
+              if: needs.chrome-extension-build.outputs.is-success == 'success'
+              run: |
+                  cat << EOF > pr_comment.md
+                  ## PR Test Pipeline Success
+                  Github Actions Log: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+                  EOF
+                  gh pr comment ${{github.event.pull_request.number}} --body-file pr_comment.md
+                  echo "PR Test Pipeline Success"
+
+            - name: "Add Failure Comment To PR"
+              if: needs.chrome-extension-build.outputs.is-success == 'failure'
+              run: |
+                  cat << EOF > pr_comment.md
+                  ## PR Test Pipeline Failed
+                  Github Actions Log: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+                  EOF
+                  gh pr comment ${{github.event.pull_request.number}} --body-file pr_comment.md
+                  echo "PR Test Pipeline Failed"

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -37,6 +37,8 @@ jobs:
         needs:
             - chrome-extension-build
         if: always()
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - name: "Add Success Comment To PR"
               if: needs.chrome-extension-build.outputs.is-success == 'success'


### PR DESCRIPTION
masterブランチへのPR作成時に、github actionsでテストビルドを行う。
将来的には`npm run test`を導入する。

ビルドが成功/失敗するブランチを作成し、github actionsの挙動をテストする必要があるため、未テストだがmergeを行う。