### PR TITLE
GCPリソース作成: 譜面情報を取得するcloud runの起動スケジューラ作成

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -212,7 +212,7 @@ resource "google_pubsub_subscription" "sheet_scraper_subscription" {
 #  sheet_scraper_triggerを起動するscheduler
 resource "google_cloud_scheduler_job" "sheet_scraper_scheduler" {
   name      = "sheet-scraper-scheduler-${local.suffix}"
-  schedule  = "1 7 * * *"
+  schedule  = "5 7 * * *"
   time_zone = "Asia/Tokyo"
 
   pubsub_target {

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -195,13 +195,17 @@ resource "google_cloud_run_service_iam_member" "sheet_scraper_invoker" {
 
 # sheet-scraperを起動するeventarcに紐付けるpub/subサブスクリプション
 resource "google_pubsub_subscription" "sheet_scraper_subscription" {
-  name  = "sheet-scraper-subscription-${local.suffix}"
-  topic = google_pubsub_topic.sheet_scraper_topic.id
+  name                 = "sheet-scraper-subscription-${local.suffix}"
+  topic                = google_pubsub_topic.sheet_scraper_topic.id
+  ack_deadline_seconds = 600
   push_config {
     oidc_token {
       service_account_email = google_service_account.sheet_scraper_subscription_sa.email
     }
     push_endpoint = google_cloud_run_service.sheet_scraper.status[0].url
+  }
+  retry_policy {
+    minimum_backoff = "600s"
   }
 }
 

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -174,6 +174,48 @@ resource "google_storage_bucket_iam_member" "sheet_storage_service_account_admin
   member = "serviceAccount:${google_service_account.sheet_scraper_sa.email}"
 }
 
+# sheet-scraperを起動するeventarcに紐付けるpub/subトピック
+resource "google_pubsub_topic" "sheet_scraper_topic" {
+  name = "sheet-scraper-topic-${local.suffix}"
+}
+
+# sheet-scraperを起動するeventarcに紐付けるpub/subサブスクリプションのIAMロール
+resource "google_service_account" "sheet_scraper_subscription_sa" {
+  account_id   = "sheet-scraper-sub-sa-${local.suffix}"
+  display_name = "Service account for pub/sub subscription to Cloud Run sheet-scraper"
+}
+
+# sheet_scraper_subscription_saにcloud runサービスのinvokerロールを付与
+resource "google_cloud_run_service_iam_member" "sheet_scraper_invoker" {
+  service  = google_cloud_run_service.sheet_scraper.name
+  location = var.region
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.sheet_scraper_subscription_sa.email}"
+}
+
+# sheet-scraperを起動するeventarcに紐付けるpub/subサブスクリプション
+resource "google_pubsub_subscription" "sheet_scraper_subscription" {
+  name  = "sheet-scraper-subscription-${local.suffix}"
+  topic = google_pubsub_topic.sheet_scraper_topic.id
+  push_config {
+    oidc_token {
+      service_account_email = google_service_account.sheet_scraper_subscription_sa.email
+    }
+    push_endpoint = google_cloud_run_service.sheet_scraper.status[0].url
+  }
+}
+
+#  sheet_scraper_triggerを起動するscheduler
+resource "google_cloud_scheduler_job" "sheet_scraper_scheduler" {
+  name      = "sheet-scraper-scheduler-${local.suffix}"
+  schedule  = "1 7 * * *"
+  time_zone = "Asia/Tokyo"
+
+  pubsub_target {
+    topic_name = google_pubsub_topic.sheet_scraper_topic.id
+    data       = base64encode(jsonencode({}))
+  }
+}
 
 output "suffix" {
   value = local.suffix


### PR DESCRIPTION
- cloud run "sheet-scraper"を起動する、pub/subトピック・サブスクリクション
- 毎日7:05のスケジューラ