### PR TITLE
#24 2つのスタックの起動時間による成否の確認

### DIFF
--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -79,6 +79,7 @@ jobs:
                   SPREAD_SHEET_ID: ${{secrets.SPREAD_SHEET_ID}}
                   SHEET_STORAGE_NAME_STG: ${{secrets.SHEET_STORAGE_NAME_STG}}
                   CURRENT_ONGEKI_VERSION_NAME: ${{secrets.CURRENT_ONGEKI_VERSION_NAME}}
+                  SHEET_SCRAPER_SCHEDULE: ${{secrets.SHEET_SCRAPER_SCHEDULE_STG}}
               run: |
                   echo "project_id = \"$PROJECT_ID\"" > ./terraform.tfvars
                   echo "region = \"$REGION\"" >> ./terraform.tfvars
@@ -88,6 +89,7 @@ jobs:
                   echo "spread_sheet_id = \"$SPREAD_SHEET_ID\"" >> ./terraform.tfvars
                   echo "sheet_storage_name = \"$SHEET_STORAGE_NAME_STG\"" >> ./terraform.tfvars
                   echo "current_ongeki_version_name = \"$CURRENT_ONGEKI_VERSION_NAME\"" >> ./terraform.tfvars
+                  echo "sheet_scraper_schedule = \"$SHEET_SCRAPER_SCHEDULE\"" >> ./terraform.tfvars
 
             - name: "Apply"
               id: "apply"
@@ -142,6 +144,7 @@ jobs:
                   PROJECT_ID: ${{secrets.PROJECT_ID}}
                   REGION: ${{secrets.REGION}}
                   ENV: "stg"
+                  SHEET_SCRAPER_SCHEDULE: ${{secrets.SHEET_SCRAPER_SCHEDULE_STG}}
               run: |
                   echo "project_id = \"$PROJECT_ID\"" > ./terraform.tfvars
                   echo "region = \"$REGION\"" >> ./terraform.tfvars
@@ -151,6 +154,7 @@ jobs:
                   echo "spread_sheet_id = \"$SPREAD_SHEET_ID\"" >> ./terraform.tfvars
                   echo "sheet_storage_name = \"$SHEET_STORAGE_NAME_STG\"" >> ./terraform.tfvars
                   echo "current_ongeki_version_name = \"$CURRENT_ONGEKI_VERSION_NAME\"" >> ./terraform.tfvars
+                  echo "sheet_scraper_schedule = \"$SHEET_SCRAPER_SCHEDULE\"" >> ./terraform.tfvars
             - name: "Plan"
               id: "plan"
               run: |

--- a/.github/workflows/master-push.yaml
+++ b/.github/workflows/master-push.yaml
@@ -109,6 +109,7 @@ jobs:
                   SPREAD_SHEET_ID: ${{secrets.SPREAD_SHEET_ID}}
                   SHEET_STORAGE_NAME_STG: ${{secrets.SHEET_STORAGE_NAME_STG}}
                   CURRENT_ONGEKI_VERSION_NAME: ${{secrets.CURRENT_ONGEKI_VERSION_NAME}}
+                  SHEET_SCRAPER_SCHEDULE: ${{secrets.SHEET_SCRAPER_SCHEDULE_STG}}
               run: |
                   echo "project_id = \"$PROJECT_ID\"" > ./terraform.tfvars
                   echo "region = \"$REGION\"" >> ./terraform.tfvars
@@ -118,6 +119,7 @@ jobs:
                   echo "spread_sheet_id = \"$SPREAD_SHEET_ID\"" >> ./terraform.tfvars
                   echo "sheet_storage_name = \"$SHEET_STORAGE_NAME_STG\"" >> ./terraform.tfvars
                   echo "current_ongeki_version_name = \"$CURRENT_ONGEKI_VERSION_NAME\"" >> ./terraform.tfvars
+                  echo "sheet_scraper_schedule = \"$SHEET_SCRAPER_SCHEDULE\"" >> ./terraform.tfvars
             - name: "Apply"
               run: |
                   terraform init

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,7 @@ jobs:
                   SPREAD_SHEET_ID: ${{secrets.SPREAD_SHEET_ID}}
                   SHEET_STORAGE_NAME_PRD: ${{secrets.SHEET_STORAGE_NAME_PRD}}
                   CURRENT_ONGEKI_VERSION_NAME: ${{secrets.CURRENT_ONGEKI_VERSION_NAME}}
+                  SHEET_SCRAPER_SCHEDULE: ${{secrets.SHEET_SCRAPER_SCHEDULE_PRD}}
               run: |
                   echo "project_id = \"$PROJECT_ID\"" > ./terraform.tfvars
                   echo "region = \"$REGION\"" >> ./terraform.tfvars
@@ -110,6 +111,7 @@ jobs:
                   echo "spread_sheet_id = \"$SPREAD_SHEET_ID\"" >> ./terraform.tfvars
                   echo "sheet_storage_name = \"$SHEET_STORAGE_NAME_PRD\"" >> ./terraform.tfvars
                   echo "current_ongeki_version_name = \"$CURRENT_ONGEKI_VERSION_NAME\"" >> ./terraform.tfvars
+                  echo "sheet_scraper_schedule = \"$SHEET_SCRAPER_SCHEDULE\"" >> ./terraform.tfvars
             - name: "Apply"
               run: |
                   terraform init

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -32,3 +32,8 @@ variable "current_ongeki_version_name" {
   description = "現在のオンゲキのバージョン名"
   type        = string
 }
+
+variable "sheet_scraper_schedule" {
+  description = "sheet-scraperのcron形式実行スケジュール(\"5 7 * * *\"など)"
+  type        = string
+}


### PR DESCRIPTION
# 概要

stgスタックとローカルから作成したスタックのsheet-scraperの起動時間が同じ・異なる場合のsheet-scraperの成否を確認するため、stgスタックにデプロイする。

# 実装内容

- 各スタックのsheet-scraperの実行時間を環境変数から変更できるようにした
