### PR TITLE
ci: gcp/とchrome-extension/にフォーマット・リント導入

### DIFF
--- a/.github/workflows/lint-chromeex/action.yaml
+++ b/.github/workflows/lint-chromeex/action.yaml
@@ -1,0 +1,56 @@
+# ######################################################################
+#
+# chrome-extensionのフォーマット・リントチェックを行う
+#
+# 前提条件:
+#   - Dockerコンテナ ongeki-score-fetch/node:24.04 を使用すること
+# ```
+# runs-on: ubuntu-latest
+# container: ongeki-score-fetch/node:24.04
+# permissions:
+#   id-token: write
+#   contents: read
+# ```
+#
+# ######################################################################
+name: LintChromeExtension
+description: chrome-extensionのフォーマット・リントチェックを行う
+outputs:
+    is-success:
+        description: チェックが成功したか("success" or "failure")
+        value: ${{ steps.set-result.outputs.result }}
+runs:
+    using: composite
+    steps:
+        - name: Install dependencies
+          working-directory: ./chrome-extension
+          shell: bash
+          run: |
+              npm install
+
+        - name: Run Prettier check
+          id: prettier
+          working-directory: ./chrome-extension
+          shell: bash
+          continue-on-error: true
+          run: |
+              npx prettier --check .
+
+        - name: Run Biome check
+          id: biome
+          working-directory: ./chrome-extension
+          shell: bash
+          continue-on-error: true
+          run: |
+              npx biome check --error-on-warnings .
+
+        - name: Set result
+          id: set-result
+          shell: bash
+          run: |
+              if [ "${{ steps.prettier.outcome }}" == "success" ] && [ "${{ steps.biome.outcome }}" == "success" ]; then
+                  echo "result=success" >> $GITHUB_OUTPUT
+              else
+                  echo "result=failure" >> $GITHUB_OUTPUT
+                  exit 1
+              fi

--- a/.github/workflows/lint-chromeex/action.yaml
+++ b/.github/workflows/lint-chromeex/action.yaml
@@ -26,7 +26,7 @@ runs:
           working-directory: ./chrome-extension
           shell: bash
           run: |
-              npm install
+              npm ci
 
         - name: Run Prettier check
           id: prettier

--- a/.github/workflows/lint-chromeex/action.yaml
+++ b/.github/workflows/lint-chromeex/action.yaml
@@ -26,7 +26,7 @@ runs:
           working-directory: ./chrome-extension
           shell: bash
           run: |
-              npm ci
+              pnpm install --frozen-lockfile
 
         - name: Run Prettier check
           id: prettier

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -13,12 +13,37 @@ jobs:
     updated-files-check:
         uses: ./.github/workflows/sub-updated-files-check.yaml
 
+    chrome-extension-lint:
+        outputs:
+            is-success: ${{steps.lint.outputs.is-success}}
+        needs:
+            - updated-files-check
+        if: ${{needs.updated-files-check.outputs.chrome-extension-updated == 'true'}}
+        runs-on: ubuntu-24.04
+        container:
+            image: ghcr.io/ano333333/ongeki-score-fetch/node:24.04
+            credentials:
+                username: ${{ github.actor }}
+                password: ${{ secrets.CR_PAT }}
+        defaults:
+            run:
+                working-directory: ./chrome-extension
+        permissions:
+            id-token: write
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: ./.github/workflows/lint-chromeex/
+              id: lint
+
     chrome-extension-build:
         outputs:
             is-success: ${{steps.build.outputs.is-success}}
         needs:
             - updated-files-check
-        if: ${{needs.updated-files-check.outputs.chrome-extension-updated == 'true'}}
+            - chrome-extension-lint
+        if: ${{needs.updated-files-check.outputs.chrome-extension-updated == 'true' && needs.chrome-extension-lint.outputs.is-success == 'success'}}
         runs-on: ubuntu-24.04
         container:
             image: ghcr.io/ano333333/ongeki-score-fetch/node:24.04
@@ -46,7 +71,8 @@ jobs:
             is-success: ${{steps.test.outputs.is-success}} # 'success' or 'failure'
         needs:
             - updated-files-check
-        if: ${{needs.updated-files-check.outputs.chrome-extension-updated == 'true'}}
+            - chrome-extension-lint
+        if: ${{needs.updated-files-check.outputs.chrome-extension-updated == 'true' && needs.chrome-extension-lint.outputs.is-success == 'success'}}
         permissions:
             id-token: write
             contents: read
@@ -69,11 +95,41 @@ jobs:
             - uses: ./.github/workflows/test-chromeex/
               id: test
 
+    gcp-lint:
+        needs:
+            - updated-files-check
+        if: ${{needs.updated-files-check.outputs.gcp-updated == 'true'}}
+        runs-on: ubuntu-24.04
+        defaults:
+            run:
+                working-directory: ./gcp
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Terraform
+              uses: hashicorp/setup-terraform@v3
+
+            - name: Terraform fmt check
+              run: terraform fmt -check -recursive
+
+            - name: Setup TFLint
+              uses: terraform-linters/setup-tflint@v4
+              with:
+                  tflint_version: latest
+
+            - name: Initialize TFLint
+              run: tflint --init
+
+            - name: Run TFLint
+              run: tflint --format compact
+
     plan-stg:
         outputs:
             is-success: ${{steps.plan.outcome}} # 'success' or 'failure'
         needs:
             - updated-files-check
+            - gcp-lint
         if: ${{needs.updated-files-check.outputs.gcp-updated == 'true'}}
         permissions:
             id-token: write
@@ -123,6 +179,7 @@ jobs:
         runs-on: ubuntu-24.04
         needs:
             - updated-files-check
+            - gcp-lint
         if: ${{needs.updated-files-check.outputs.gcp-updated == 'true'}}
         defaults:
             run:

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -12,7 +12,7 @@ classDiagram
     class UserDataSource {
     }
     IUserDataSource <|-- UserDataSource
-    
+
     class IScoreDataSource {
         <<interface>>
     }
@@ -104,7 +104,7 @@ classDiagram
 
 - **View層**: .vueファイルとして実装。ライフタイムの開始時にcontrollerをインスタンス化し、各インターフェースをDIする
 - **Controller層**: データフローとビジネスロジックを担当し、状態を持たない
-- **状態管理**: 
+- **状態管理**:
   - 1つのライフタイムのみで用いられる状態はviewが管理
   - 複数のライフタイムで用いられる状態の永続化はLocalStorageが行う
 - **データフェッチ処理**: ポップアップの1ライフタイムに収まらないため、1つのoffscreenで行う
@@ -228,6 +228,7 @@ title,genre,character,versionMaster,versionLunatic,constantBasic,constantAdvance
 ```
 
 **カラム説明**:
+
 - title: 楽曲の正式名称
 - genre: 楽曲ジャンル分類
 - character: 担当キャラクター名
@@ -257,35 +258,35 @@ Chrome Extension内部のコンポーネント間通信は、型安全なメッ�
 
 ```ts
 export type ChrExtRuntimeMessageType =
-    | {
-        type: "is-fetch-processing";
-        from: "popup";
-        to: "backgroundWorker";
-      }
-    | {
-        type: "start-fetch";
-        from: "popup";
-        to: "backgroundWorker";
-      }
-    | {
-        type: "start-fetch";
-        from: "backgroundWorker";
-        to: "offscreenDataFetch";
-      }
-    | {
-        type: "save-fetch-log";
-        from: "offscreenDataFetch";
-        to: "backgroundWorker";
-        logType: "progress" | "error" | "finish";
-        logMessage: string;
-      }
-    | {
-        type: "fetch-finished";
-        from: "offscreenDataFetch";
-        to: "backgroundWorker";
-        datas: OutputTargetDataRowType[];
-        error?: string;
-      };
+  | {
+      type: "is-fetch-processing";
+      from: "popup";
+      to: "backgroundWorker";
+    }
+  | {
+      type: "start-fetch";
+      from: "popup";
+      to: "backgroundWorker";
+    }
+  | {
+      type: "start-fetch";
+      from: "backgroundWorker";
+      to: "offscreenDataFetch";
+    }
+  | {
+      type: "save-fetch-log";
+      from: "offscreenDataFetch";
+      to: "backgroundWorker";
+      logType: "progress" | "error" | "finish";
+      logMessage: string;
+    }
+  | {
+      type: "fetch-finished";
+      from: "offscreenDataFetch";
+      to: "backgroundWorker";
+      datas: OutputTargetDataRowType[];
+      error?: string;
+    };
 ```
 
 ### 通信フロー
@@ -300,41 +301,41 @@ export type ChrExtRuntimeMessageType =
 
 ```ts
 export type BeatmapDataType = {
-    name: string;
-    genre: string | undefined;
-    character: string | undefined;
-    version: string | undefined;
-    difficulty: BeatmapDataDifficultyType;
-    const: number | undefined;
+  name: string;
+  genre: string | undefined;
+  character: string | undefined;
+  version: string | undefined;
+  difficulty: BeatmapDataDifficultyType;
+  const: number | undefined;
 };
 
 export type BeatmapDataDifficultyType =
-    | "BASIC"
-    | "ADVANCED"
-    | "EXPERT"
-    | "MASTER"
-    | "LUNATIC";
+  | "BASIC"
+  | "ADVANCED"
+  | "EXPERT"
+  | "MASTER"
+  | "LUNATIC";
 ```
 
 ### OutputTargetDataRowType（出力データ）
 
 ```ts
 export type OutputTargetDataRowType = {
-    difficulty: OutputTargetDataRowDifficultyType;
-    level: string;
-    name: string;
-    genre: string;
-    technicalHighScore: number;
-    overDamageHighScore: number;
-    battleHighScore: number;
-    fullBell: boolean;
-    allBreak: boolean;
-    const: number | undefined;
-    platinumHighScore: number;
-    platinumStar: number;
-    platinumMaxScore: number;
-    character: string | undefined;
-    version: string | undefined;
+  difficulty: OutputTargetDataRowDifficultyType;
+  level: string;
+  name: string;
+  genre: string;
+  technicalHighScore: number;
+  overDamageHighScore: number;
+  battleHighScore: number;
+  fullBell: boolean;
+  allBreak: boolean;
+  const: number | undefined;
+  platinumHighScore: number;
+  platinumStar: number;
+  platinumMaxScore: number;
+  character: string | undefined;
+  version: string | undefined;
 };
 ```
 
@@ -344,20 +345,20 @@ export type OutputTargetDataRowType = {
 
 ```ts
 export type RawLocalStorageVer1Type = {
-    version: 1;
-    progresses: Array<{
-        createdAt: number;
-        message: string;
-        type: "progress" | "error" | "finished";
-    }>;
-    outputTarget: "download" | "dropbox";
-    outputTargetOptions: {
-        dropbox: {
-            outputPath: string;
-            accessToken?: string;
-            expires?: number;
-        };
+  version: 1;
+  progresses: Array<{
+    createdAt: number;
+    message: string;
+    type: "progress" | "error" | "finished";
+  }>;
+  outputTarget: "download" | "dropbox";
+  outputTargetOptions: {
+    dropbox: {
+      outputPath: string;
+      accessToken?: string;
+      expires?: number;
     };
+  };
 };
 ```
 
@@ -365,14 +366,14 @@ export type RawLocalStorageVer1Type = {
 
 ```ts
 export const defaultRawLocalStorageVer1 = {
-    version: 1,
-    progresses: [],
-    outputTarget: "download",
-    outputTargetOptions: {
-        dropbox: {
-            outputPath: "ongeki-score-fetch/data.csv",
-        },
+  version: 1,
+  progresses: [],
+  outputTarget: "download",
+  outputTargetOptions: {
+    dropbox: {
+      outputPath: "ongeki-score-fetch/data.csv",
     },
+  },
 } as const;
 ```
 
@@ -386,19 +387,19 @@ export const defaultRawLocalStorageVer1 = {
 
 ```ts
 export type LocalStorageType = {
-    progresses: Array<{
-        createdAt: number;
-        message: string;
-        type: "progress" | "error" | "finish";
-    }>;
-    outputTarget: "download" | "dropbox";
-    outputTargetOptions: {
-        dropbox: {
-            outputPath: string;
-            accessToken: string | undefined;
-            expires: number | undefined;
-        };
+  progresses: Array<{
+    createdAt: number;
+    message: string;
+    type: "progress" | "error" | "finish";
+  }>;
+  outputTarget: "download" | "dropbox";
+  outputTargetOptions: {
+    dropbox: {
+      outputPath: string;
+      accessToken: string | undefined;
+      expires: number | undefined;
     };
+  };
 };
 ```
 
@@ -407,7 +408,7 @@ export type LocalStorageType = {
 ### データソース
 
 - **IUserDataSource/UserDataSource**: ユーザーデータの取得
-- **IScoreDataSource/ScoreDataSource**: スコアデータの取得  
+- **IScoreDataSource/ScoreDataSource**: スコアデータの取得
 - **IBeatmapDataSource**: 譜面データの取得（抽象化）
   - **OngekiScoreLogBeatmapDataSource**: オンゲキスコアログからの譜面データ取得
   - **GcsBeatmapDataSource**: Google Cloud Storageからの譜面データ取得
@@ -428,4 +429,4 @@ export type LocalStorageType = {
 
 - **IBackgroundWorker/ChrExtBackgroundWorker**: Background Workerとの通信インターフェース
 - **BackgroundWorker**: Chrome Extension のbackground script
-- **Offscreen**: Chrome Extension のoffscreen document 
+- **Offscreen**: Chrome Extension のoffscreen document

--- a/chrome-extension/postcss.config.js
+++ b/chrome-extension/postcss.config.js
@@ -3,4 +3,4 @@ export default {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/chrome-extension/src/adapters/beatmapDataSource/gcsBeatmapDataSource.ts
+++ b/chrome-extension/src/adapters/beatmapDataSource/gcsBeatmapDataSource.ts
@@ -1,9 +1,9 @@
+import Papa from "papaparse";
 import type {
 	BeatmapDataDifficultyType,
 	BeatmapDataType,
 	IBeatmapDataSource,
 } from "./base";
-import Papa from "papaparse";
 
 export class GcsBeatmapDataSource implements IBeatmapDataSource {
 	constructor(private readonly bucketUrl: string) {}
@@ -14,39 +14,40 @@ export class GcsBeatmapDataSource implements IBeatmapDataSource {
 		await logger("クラウドから譜面の属性情報を取得開始");
 
 		let dataUrl: string;
-		
+
 		try {
 			// まずメタデータを取得して最新ファイル名を取得
 			await logger("メタデータファイルを確認中...");
 			const metadataUrl = `${this.bucketUrl}/result-latest.json`;
 			const metadataResponse = await fetch(metadataUrl, {
-				cache: 'no-cache' // 常にサーバーから最新のメタデータを取得
+				cache: "no-cache", // 常にサーバーから最新のメタデータを取得
 			});
-			
+
 			if (!metadataResponse.ok) {
 				throw new Error(`メタデータ取得に失敗: ${metadataResponse.status}`);
 			}
-			
+
 			const metadata = await metadataResponse.json();
 			const latestFileName = metadata.latestFileName;
-			
+
 			if (!latestFileName) {
 				throw new Error("メタデータに最新ファイル名が存在しません");
 			}
-			
+
 			dataUrl = `${this.bucketUrl}/${latestFileName}`;
 			await logger(`最新ファイルを使用: ${latestFileName}`);
-			
 		} catch (error) {
 			// メタデータ取得に失敗した場合、result.csvをフォールバックとして使用
-			await logger("メタデータ取得に失敗、result.csvをフォールバックとして使用");
+			await logger(
+				"メタデータ取得に失敗、result.csvをフォールバックとして使用",
+			);
 			console.warn("メタデータ取得に失敗、result.csvを使用:", error);
 			dataUrl = `${this.bucketUrl}/result.csv`;
 		}
 
 		// 実際のCSVデータを取得
 		const response = await fetch(dataUrl, {
-			cache: 'default' // ブラウザのデフォルトキャッシュ戦略を使用
+			cache: "default", // ブラウザのデフォルトキャッシュ戦略を使用
 		});
 		if (!response.ok) {
 			throw new Error(`CSVデータ取得に失敗: ${response.status}`);
@@ -54,7 +55,7 @@ export class GcsBeatmapDataSource implements IBeatmapDataSource {
 		const rawDatas = await response.text();
 		const csv = await this.parse(rawDatas);
 
-		const beatmapDatas = new Array<BeatmapDataType>();
+		const beatmapDatas: BeatmapDataType[] = [];
 		for (const row of csv) {
 			const createRow = (
 				row: string[],
@@ -95,4 +96,4 @@ export class GcsBeatmapDataSource implements IBeatmapDataSource {
 			});
 		});
 	}
-} 
+}

--- a/chrome-extension/src/adapters/beatmapDataSource/ongekiScoreLogBeatmapDataSource.ts
+++ b/chrome-extension/src/adapters/beatmapDataSource/ongekiScoreLogBeatmapDataSource.ts
@@ -1,9 +1,9 @@
+import Papa from "papaparse";
 import type {
 	BeatmapDataDifficultyType,
 	BeatmapDataType,
 	IBeatmapDataSource,
 } from "./base";
-import Papa from "papaparse";
 
 export class OngekiScoreLogBeatmapDataSource implements IBeatmapDataSource {
 	async getBeatmapData(
@@ -14,7 +14,7 @@ export class OngekiScoreLogBeatmapDataSource implements IBeatmapDataSource {
 		const response = await fetch(import.meta.env.VITE_BEATMAP_DATA_SOURCE_URL);
 		const rawDatas = await response.text();
 		const csv = await this.parse(rawDatas);
-		const beatmapDatas = new Array<BeatmapDataType>();
+		const beatmapDatas: BeatmapDataType[] = [];
 		for (const row of csv) {
 			const createRow = (
 				row: string[],

--- a/chrome-extension/src/adapters/outputTargetFactory/mockOutputTargetFactory.ts
+++ b/chrome-extension/src/adapters/outputTargetFactory/mockOutputTargetFactory.ts
@@ -1,5 +1,5 @@
-import type { IOutputTargetFactory } from "./base";
 import type { OutputTargetType } from "../outputTargetType";
+import type { IOutputTargetFactory } from "./base";
 
 export default class MockOutputTargetFactory implements IOutputTargetFactory {
 	getDownloadOutputTarget(): OutputTargetType<void> {

--- a/chrome-extension/src/adapters/outputTargetFactory/productionOutputTargetFactory.ts
+++ b/chrome-extension/src/adapters/outputTargetFactory/productionOutputTargetFactory.ts
@@ -1,8 +1,8 @@
-import type { IOutputTargetFactory } from "./base";
 import type {
 	OutputTargetDataRowType,
 	OutputTargetType,
 } from "../outputTargetType";
+import type { IOutputTargetFactory } from "./base";
 
 type DropboxTokenIssueResponseType = {
 	access_token: string;
@@ -37,7 +37,7 @@ export default class ProductionOutputTargetFactory
 		return async (datas, option, logger) => {
 			await logger("dropboxへの認証開始");
 			let accessToken = "";
-			let newExpires = undefined;
+			let newExpires: number | undefined;
 			if (
 				option.accessToken &&
 				option.expires &&

--- a/chrome-extension/src/adapters/userDataSource/ongekiMypageUserDataSource.ts
+++ b/chrome-extension/src/adapters/userDataSource/ongekiMypageUserDataSource.ts
@@ -199,6 +199,7 @@ export class OngekiMypageUserDataSource implements IUserDataSource {
 					//("1,033,501" --replace-> "1033,501" --replace-> "1033501" --parseInt-> 1033501)
 					const battleHighScore = Number.parseInt(
 						battleHighScoreStr.replace(",", "").replace(",", ""),
+						10,
 					);
 					const table0tbodytr1td2 =
 						table0tbodytr1.getElementsByTagName("td")[2];
@@ -206,6 +207,7 @@ export class OngekiMypageUserDataSource implements IUserDataSource {
 					//「,」を除去し、intに変換
 					const technicalHighScore = Number.parseInt(
 						technicalHighScoreStr.replace(",", "").replace(",", ""),
+						10,
 					);
 					const div1 = formdivs[1];
 					const div1table0 = div1.getElementsByTagName("table")[0];
@@ -252,10 +254,12 @@ export class OngekiMypageUserDataSource implements IUserDataSource {
 					// "1,462" -> "1462" -> 1462
 					const platinumHighScore = Number.parseInt(
 						platinumHighScoreStr.replace(",", ""),
+						10,
 					);
 					// "1,536" -> "1536" -> 1536
 					const platinumMaxScore = Number.parseInt(
 						platinumMaxScoreStr.replace(",", ""),
+						10,
 					);
 					const div1div0 = getDirectDivChildren(div1)[0];
 					const div1imgs = div1div0.getElementsByTagName("img");

--- a/chrome-extension/src/controllers/optionsController.ts
+++ b/chrome-extension/src/controllers/optionsController.ts
@@ -37,7 +37,7 @@ export class OptionsController {
 	 */
 	isOutputPathValid(path: string) {
 		// パスに使用できない文字が含まれていればfalse
-		const unusable = /[\\:\*\?\"<>\|]/;
+		const unusable = /[\\:*?"<>|]/;
 		if (path.search(unusable) !== -1) {
 			return false;
 		}

--- a/chrome-extension/src/controllers/popupController.ts
+++ b/chrome-extension/src/controllers/popupController.ts
@@ -1,5 +1,5 @@
-import type { LocalStorage, LocalStorageType } from "../adapters/localStorage";
 import type { IBackgroundWorker } from "../adapters/backgroundWorker/base";
+import type { LocalStorage, LocalStorageType } from "../adapters/localStorage";
 
 export class PopupController {
 	constructor(
@@ -20,20 +20,5 @@ export class PopupController {
 
 	async fetchAndOutputData() {
 		await this.backgroundWorker.fetchAndOutput();
-	}
-	/**
-	 * ローカルストレージのprogressesとbackgroundWorkerの稼働状況の一貫性を確認し、矛盾する場合エラーメッセージを最後に追加する
-	 */
-	private async checkProgressesAndBackgroundWorkerConsistency() {
-		const progress = (await this.localStorage.getProgresses()).at(-1);
-		const isBackgroundWorkerFetching =
-			await this.backgroundWorker.isDataFetching();
-		if (progress?.type === "progress" && !isBackgroundWorkerFetching) {
-			await this.localStorage.appendProgresses({
-				createdAt: Date.now(),
-				type: "error",
-				message: "データフェッチ・出力が中断されました",
-			});
-		}
 	}
 }

--- a/chrome-extension/src/controllers/popupController.ts
+++ b/chrome-extension/src/controllers/popupController.ts
@@ -8,10 +8,14 @@ export class PopupController {
 		progressesListener: (progress: LocalStorageType["progresses"]) => void,
 	) {
 		this.localStorage.addProgressesListener(progressesListener);
-		this.localStorage
-			.validateRawLocalStorage()
-			.then(() => this.checkProgressesAndBackgroundWorkerConsistency())
-			.catch((e) => console.error(e));
+		(async () => {
+			try {
+				await this.localStorage.validateRawLocalStorage();
+				await this.checkProgressesAndBackgroundWorkerConsistency();
+			} catch (e) {
+				console.error(e);
+			}
+		})();
 	}
 
 	async getLocalStorageProgresses() {
@@ -20,5 +24,21 @@ export class PopupController {
 
 	async fetchAndOutputData() {
 		await this.backgroundWorker.fetchAndOutput();
+	}
+
+	/**
+	 * ローカルストレージのprogressesとbackgroundWorkerの稼働状況の一貫性を確認し、矛盾する場合エラーメッセージを最後に追加する
+	 */
+	private async checkProgressesAndBackgroundWorkerConsistency() {
+		const progress = (await this.localStorage.getProgresses()).at(-1);
+		const isBackgroundWorkerFetching =
+			await this.backgroundWorker.isDataFetching();
+		if (progress?.type === "progress" && !isBackgroundWorkerFetching) {
+			await this.localStorage.appendProgresses({
+				createdAt: Date.now(),
+				type: "error",
+				message: "データフェッチ・出力が中断されました",
+			});
+		}
 	}
 }

--- a/chrome-extension/src/offscreenDataFetch.html
+++ b/chrome-extension/src/offscreenDataFetch.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
-    <title>ongeki-score-fetch offscreen</title>
+  <title>ongeki-score-fetch offscreen</title>
 </head>
 <body>
-    <script type="module" src="./offscreens/dataFetch.ts"></script>
+  <script type="module" src="./offscreens/dataFetch.ts"></script>
 </body>

--- a/chrome-extension/src/offscreens/dataFetch.ts
+++ b/chrome-extension/src/offscreens/dataFetch.ts
@@ -1,12 +1,12 @@
-import type { UserDataScoreType } from "../adapters/userDataSource/base";
 import type {
 	BeatmapDataDifficultyType,
 	BeatmapDataType,
 } from "../adapters/beatmapDataSource/base";
-import type { OutputTargetDataRowType } from "../adapters/outputTargetType";
-import type { ChrExtRuntimeMessageType } from "../messages";
-import { OngekiMypageUserDataSource } from "../adapters/userDataSource/ongekiMypageUserDataSource";
 import { GcsBeatmapDataSource } from "../adapters/beatmapDataSource/gcsBeatmapDataSource";
+import type { OutputTargetDataRowType } from "../adapters/outputTargetType";
+import type { UserDataScoreType } from "../adapters/userDataSource/base";
+import { OngekiMypageUserDataSource } from "../adapters/userDataSource/ongekiMypageUserDataSource";
+import type { ChrExtRuntimeMessageType } from "../messages";
 
 console.log("start offscreenDataFetch.ts");
 
@@ -23,7 +23,9 @@ const fetch = async () => {
 	console.log("offscreenDataFetch.ts: fetch");
 	try {
 		const userDataSource = new OngekiMypageUserDataSource();
-		const beatmapDataSource = new GcsBeatmapDataSource(import.meta.env.VITE_BEATMAP_DATA_BUCKET_URL);
+		const beatmapDataSource = new GcsBeatmapDataSource(
+			import.meta.env.VITE_BEATMAP_DATA_BUCKET_URL,
+		);
 
 		const logger = async (log: string) => {
 			console.log(`offscreenDataFetch.ts: ${log}`);
@@ -39,7 +41,7 @@ const fetch = async () => {
 		let userDatas: UserDataScoreType[] = [];
 		try {
 			userDatas = await userDataSource.getUserData(logger);
-		} catch (e) {
+		} catch (_e) {
 			throw "ユーザーデータ取得中にエラーが発生しました。再ログインしてください。";
 		}
 		const beatmapDatas = await beatmapDataSource.getBeatmapData(logger);

--- a/chrome-extension/src/options.html
+++ b/chrome-extension/src/options.html
@@ -1,17 +1,17 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-    <head>
-        <title>options</title>
-        <link rel="stylesheet" href="style.css" />
-    </head>
-    <body>
-        <div id="app"></div>
-        <script type="module">
-            import { createApp } from "vue";
-            import "./style.css";
-            import options from "./views/options.vue";
+  <head>
+    <title>options</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import { createApp } from "vue";
+      import "./style.css";
+      import options from "./views/options.vue";
 
-            createApp(options).mount("#app");
-        </script>
-    </body>
+      createApp(options).mount("#app");
+    </script>
+  </body>
 </html>

--- a/chrome-extension/src/popup.html
+++ b/chrome-extension/src/popup.html
@@ -1,17 +1,17 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-    <head>
-        <title>title</title>
-        <link rel="stylesheet" href="style.css" />
-    </head>
-    <body>
-        <div id="app"></div>
-        <script type="module">
-            import { createApp } from "vue";
-            import "./style.css";
-            import popup from "./views/popup.vue";
+  <head>
+    <title>title</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import { createApp } from "vue";
+      import "./style.css";
+      import popup from "./views/popup.vue";
 
-            createApp(popup).mount("#app");
-        </script>
-    </body>
+      createApp(popup).mount("#app");
+    </script>
+  </body>
 </html>

--- a/chrome-extension/src/public/manifest.json
+++ b/chrome-extension/src/public/manifest.json
@@ -1,31 +1,31 @@
 {
-    "name": "ongeki-score-fetch",
-    "version": "1.0",
-    "manifest_version": 3,
-    "description": "Fetches scores from Ongeki game.",
-    "action": {
-        "default_popup": "popup.html"
-    },
-    "host_permissions": [
-        "https://ongeki-net.com/ongeki-mobile/*",
-        "https://ongeki-score.net/music",
-        "https://www.dropbox.com/oauth2/authorize",
-        "https://content.dropboxapi.com/2/files/upload",
-        "https://storage.googleapis.com/sheet-storage-*/*"
-    ],
-    "permissions": ["cookies", "storage", "offscreen", "downloads", "tabs"],
-    "background": {
-        "service_worker": "background.js",
-        "type": "module"
-    },
-    "options_ui": {
-        "page": "options.html",
-        "open_in_tab": false
-    },
-    "web_accessible_resources": [
-        {
-            "resources": ["redirect.html"],
-            "matches": ["https://www.dropbox.com/*"]
-        }
-    ]
+	"name": "ongeki-score-fetch",
+	"version": "1.0",
+	"manifest_version": 3,
+	"description": "Fetches scores from Ongeki game.",
+	"action": {
+		"default_popup": "popup.html"
+	},
+	"host_permissions": [
+		"https://ongeki-net.com/ongeki-mobile/*",
+		"https://ongeki-score.net/music",
+		"https://www.dropbox.com/oauth2/authorize",
+		"https://content.dropboxapi.com/2/files/upload",
+		"https://storage.googleapis.com/sheet-storage-*/*"
+	],
+	"permissions": ["cookies", "storage", "offscreen", "downloads", "tabs"],
+	"background": {
+		"service_worker": "background.js",
+		"type": "module"
+	},
+	"options_ui": {
+		"page": "options.html",
+		"open_in_tab": false
+	},
+	"web_accessible_resources": [
+		{
+			"resources": ["redirect.html"],
+			"matches": ["https://www.dropbox.com/*"]
+		}
+	]
 }

--- a/chrome-extension/src/redirect.html
+++ b/chrome-extension/src/redirect.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-    <title>redirect - ongeki-score-fetch</title>
-    <body>
-        redirecting...
-    </body>
+  <title>redirect - ongeki-score-fetch</title>
+  <body>
+    redirecting...
+  </body>
 </html>

--- a/chrome-extension/src/shims-vue.d.ts
+++ b/chrome-extension/src/shims-vue.d.ts
@@ -1,5 +1,7 @@
 declare module "*.vue" {
 	import type { DefineComponent } from "vue";
+	// biome-ignore lint/complexity/noBannedTypes: Vue type definition requires empty object types
+	// biome-ignore lint/suspicious/noExplicitAny: Vue type definition requires any
 	const component: DefineComponent<{}, {}, any>;
 	export default component;
 }

--- a/chrome-extension/src/views/components/alert.vue
+++ b/chrome-extension/src/views/components/alert.vue
@@ -1,41 +1,41 @@
 <template>
-    <!-- TODO:何故かspanの色が全く変わらない -->
-    <div class="rounded-md border border-gray-200 p-2">
-        <span :class="iconClass">{{ iconString }}</span>
-        <slot />
-    </div>
+  <!-- TODO:何故かspanの色が全く変わらない -->
+  <div class="rounded-md border border-gray-200 p-2">
+    <span :class="iconClass">{{ iconString }}</span>
+    <slot />
+  </div>
 </template>
 <script setup lang="ts">
 import { defineProps, computed } from "vue";
 const props = defineProps<{
-    type: "success" | "error";
+  type: "success" | "error";
 }>();
 const iconClassBase = [
-    "rounded-full",
-    "border",
-    "px-2",
-    "py-1",
-    "font-medium",
-    "m-1",
+  "rounded-full",
+  "border",
+  "px-2",
+  "py-1",
+  "font-medium",
+  "m-1",
 ];
 const iconClass = computed(() => {
-    let color = "";
-    switch (props.type) {
-        case "success":
-            color = "green";
-            break;
-        case "error":
-            color = "red";
-            break;
-    }
-    return [...iconClassBase, `text-${color}-700`, `border-${color}-400`];
+  let color = "";
+  switch (props.type) {
+    case "success":
+      color = "green";
+      break;
+    case "error":
+      color = "red";
+      break;
+  }
+  return [...iconClassBase, `text-${color}-700`, `border-${color}-400`];
 });
 const iconString = computed(() => {
-    switch (props.type) {
-        case "success":
-            return "✓";
-        case "error":
-            return "✕";
-    }
+  switch (props.type) {
+    case "success":
+      return "✓";
+    case "error":
+      return "✕";
+  }
 });
 </script>

--- a/chrome-extension/src/views/components/button.vue
+++ b/chrome-extension/src/views/components/button.vue
@@ -1,23 +1,23 @@
 <template>
-    <button
-        type="button"
-        @click="emits('click')"
-        :disabled="props.disabled"
-        class="rounded-md px-2.5 py-1.5 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:text-gray-300 disabled:hover:bg-white"
-    >
-        <slot />
-    </button>
+  <button
+    type="button"
+    @click="emits('click')"
+    :disabled="props.disabled"
+    class="rounded-md px-2.5 py-1.5 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:text-gray-300 disabled:hover:bg-white"
+  >
+    <slot />
+  </button>
 </template>
 <script setup lang="ts">
 import { defineProps, defineEmits } from "vue";
 
 const props = defineProps({
-    disabled: {
-        type: Boolean,
-        default: false,
-    },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
 });
 const emits = defineEmits<{
-    (e: "click"): void;
+  (e: "click"): void;
 }>();
 </script>

--- a/chrome-extension/src/views/options.vue
+++ b/chrome-extension/src/views/options.vue
@@ -1,69 +1,63 @@
 <template>
-    <div class="m-4">
-        <h1 class="m-2 text-lg">オプション</h1>
-        <div v-if="!outputTargetOptions">
-            <p class="text-gray-400">オプションデータを読み込み中</p>
-        </div>
-        <div v-else>
-            <div class="m-2 p-4 border border-gray-400 rounded-md">
-                <div class="m-2">
-                    <label
-                        for="outputType"
-                        class="block text-sm font-medium leading-6"
-                    >
-                        出力方法
-                    </label>
-                    <div class="mt-2">
-                        <select
-                            id="outputType"
-                            v-model="outputTarget"
-                            class="block w-full rounded-md border-0 py-1.5 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:max-w-xs sm:text-sm sm:leading-6"
-                        >
-                            <option
-                                v-for="outputType in outputTypeList"
-                                :key="outputType.value"
-                                :value="outputType.value"
-                            >
-                                {{ outputType.text }}
-                            </option>
-                        </select>
-                    </div>
-                </div>
-                <div class="m-2">
-                    <label
-                        for="outputPath"
-                        class="block text-sm font-medium leading-6"
-                        >出力先ファイルパス<br /><span
-                            class="text-gray-400 leading-4"
-                            >Dropboxに保存する際このパス・ファイル名で保存します</span
-                        ></label
-                    >
-                    <input
-                        v-model="outputTargetOptions.dropbox.outputPath"
-                        id="outputPath"
-                        type="text"
-                        class="block w-full rounded-md border-0 px-1.5 py-1.5 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:max-w-xs sm:text-sm sm:leading-6"
-                    />
-                    <p
-                        v-if="!isOutputPathValid"
-                        class="text-sm mt-1 font-bold text-red-400"
-                    >
-                        パスが不正です。拡張子は.csvまたは.txtにしてください。
-                    </p>
-                </div>
-            </div>
-            <button
-                :disabled="isProcessing"
-                @click="saveOnClick()"
-                class="m-2 p-2 border border-gray-400 rounded-md disabled:bg-gray-300"
-            >
-                保存
-            </button>
-            <p v-if="isProcessing" class="text-red-400 text-sm">
-                データ取得中は更新できません
-            </p>
-        </div>
+  <div class="m-4">
+    <h1 class="m-2 text-lg">オプション</h1>
+    <div v-if="!outputTargetOptions">
+      <p class="text-gray-400">オプションデータを読み込み中</p>
     </div>
+    <div v-else>
+      <div class="m-2 p-4 border border-gray-400 rounded-md">
+        <div class="m-2">
+          <label for="outputType" class="block text-sm font-medium leading-6">
+            出力方法
+          </label>
+          <div class="mt-2">
+            <select
+              id="outputType"
+              v-model="outputTarget"
+              class="block w-full rounded-md border-0 py-1.5 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:max-w-xs sm:text-sm sm:leading-6"
+            >
+              <option
+                v-for="outputType in outputTypeList"
+                :key="outputType.value"
+                :value="outputType.value"
+              >
+                {{ outputType.text }}
+              </option>
+            </select>
+          </div>
+        </div>
+        <div class="m-2">
+          <label for="outputPath" class="block text-sm font-medium leading-6"
+            >出力先ファイルパス<br /><span class="text-gray-400 leading-4"
+              >Dropboxに保存する際このパス・ファイル名で保存します</span
+            ></label
+          >
+          <input
+            v-model="outputTargetOptions.dropbox.outputPath"
+            id="outputPath"
+            type="text"
+            class="block w-full rounded-md border-0 px-1.5 py-1.5 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:max-w-xs sm:text-sm sm:leading-6"
+          />
+          <p
+            v-if="!isOutputPathValid"
+            class="text-sm mt-1 font-bold text-red-400"
+          >
+            パスが不正です。拡張子は.csvまたは.txtにしてください。
+          </p>
+        </div>
+      </div>
+      <button
+        :disabled="isProcessing"
+        @click="saveOnClick()"
+        class="m-2 p-2 border border-gray-400 rounded-md disabled:bg-gray-300"
+      >
+        保存
+      </button>
+      <p v-if="isProcessing" class="text-red-400 text-sm">
+        データ取得中は更新できません
+      </p>
+    </div>
+  </div>
 </template>
 <script setup lang="ts">
 import { LocalStorage, type LocalStorageType } from "../adapters/localStorage";
@@ -72,42 +66,50 @@ import { OptionsController } from "../controllers/optionsController";
 import { ChrExtLocalStorage } from "../adapters/rawLocalStorage/chrExtLocalStorage";
 
 const controller = new OptionsController(
-    new LocalStorage(new ChrExtLocalStorage()),
-    updateIsProcessing,
+  new LocalStorage(new ChrExtLocalStorage()),
+  updateIsProcessing,
 );
 
 const outputTarget = ref<LocalStorageType["outputTarget"]>("download");
 const outputTargetOptions = ref<LocalStorageType["outputTargetOptions"]>({
-    dropbox: {
-        outputPath: "",
-        accessToken: undefined,
-        expires: undefined,
-    },
+  dropbox: {
+    outputPath: "",
+    accessToken: undefined,
+    expires: undefined,
+  },
 });
 
-const outputTypeList: { value: LocalStorageType["outputTarget"]; text: string }[] = [
-    { value: "download", text: "ダウンロード" },
-    { value: "dropbox", text: "Dropbox" },
+const outputTypeList: {
+  value: LocalStorageType["outputTarget"];
+  text: string;
+}[] = [
+  { value: "download", text: "ダウンロード" },
+  { value: "dropbox", text: "Dropbox" },
 ];
 
 const isProcessing = ref(true);
 function updateIsProcessing(progresses: LocalStorageType["progresses"]) {
-    const lastProgress = progresses.at(-1);
-    isProcessing.value = lastProgress?.type === "progress";
-};
+  const lastProgress = progresses.at(-1);
+  isProcessing.value = lastProgress?.type === "progress";
+}
 
 onMounted(async () => {
-    outputTarget.value = await controller.getOutputTarget();
-    outputTargetOptions.value = await controller.getOutputTargetOptions();
-    updateIsProcessing(await controller.getProgresses());
+  outputTarget.value = await controller.getOutputTarget();
+  outputTargetOptions.value = await controller.getOutputTargetOptions();
+  updateIsProcessing(await controller.getProgresses());
 });
 
 //「保存」ボタンのクリックイベント
 const saveOnClick = () => {
-    controller.setOutputTargetAndOptions(outputTarget.value, outputTargetOptions.value);
+  controller.setOutputTargetAndOptions(
+    outputTarget.value,
+    outputTargetOptions.value,
+  );
 };
 
 const isOutputPathValid = computed(() => {
-    return controller.isOutputPathValid(outputTargetOptions.value.dropbox.outputPath);
+  return controller.isOutputPathValid(
+    outputTargetOptions.value.dropbox.outputPath,
+  );
 });
 </script>

--- a/chrome-extension/src/views/popup.vue
+++ b/chrome-extension/src/views/popup.vue
@@ -1,42 +1,35 @@
 <template>
-    <div class="w-80">
-        <div class="m-2">
-            <Alert v-if="isProcessing" type="error">
-                情報取得中です
-            </Alert>
-            <Alert v-else type="success">
-                情報取得可能です
-            </Alert>
-        </div>
-        <div class="m-2">
-            <Button
-                @click="onclick"
-                :disabled="isProcessing"
-            >
-                スコア情報取得
-            </Button>
-        </div>
-        <div class="m-2">
-            <div class="h-64 overflow-y-auto border rounded border-gray-500">
-                <div
-                    v-for="[index, progress] in progresses.entries()"
-                    :key="index"
-                    class="m-2"
-                >
-                    <p v-if="progress.type === 'progress'">
-                        {{ progress.message }}
-                    </p>
-                    <p v-if="progress.type === 'finish'" class="text-green-400">
-                        完了しました
-                    </p>
-                    <p v-if="progress.type === 'error'" class="text-red-400">
-                        {{ progress.message }}
-                    </p>
-                    <hr v-if="index !== progresses.length - 1" />
-                </div>
-            </div>
-        </div>
+  <div class="w-80">
+    <div class="m-2">
+      <Alert v-if="isProcessing" type="error"> 情報取得中です </Alert>
+      <Alert v-else type="success"> 情報取得可能です </Alert>
     </div>
+    <div class="m-2">
+      <Button @click="onclick" :disabled="isProcessing">
+        スコア情報取得
+      </Button>
+    </div>
+    <div class="m-2">
+      <div class="h-64 overflow-y-auto border rounded border-gray-500">
+        <div
+          v-for="[index, progress] in progresses.entries()"
+          :key="index"
+          class="m-2"
+        >
+          <p v-if="progress.type === 'progress'">
+            {{ progress.message }}
+          </p>
+          <p v-if="progress.type === 'finish'" class="text-green-400">
+            完了しました
+          </p>
+          <p v-if="progress.type === 'error'" class="text-red-400">
+            {{ progress.message }}
+          </p>
+          <hr v-if="index !== progresses.length - 1" />
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 <script setup lang="ts">
 import { onMounted, ref, computed } from "vue";
@@ -48,28 +41,28 @@ import { ChrExtLocalStorage } from "../adapters/rawLocalStorage/chrExtLocalStora
 import { ChrExtBacktroundWorker } from "../adapters/backgroundWorker/chrExtBacktroundWorker";
 
 const controller = new PopupController(
-    new LocalStorage(new ChrExtLocalStorage()),
-    new ChrExtBacktroundWorker(),
-    (newProgresses: LocalStorageType["progresses"]) => {
-        progresses.value = newProgresses;
-    },
+  new LocalStorage(new ChrExtLocalStorage()),
+  new ChrExtBacktroundWorker(),
+  (newProgresses: LocalStorageType["progresses"]) => {
+    progresses.value = newProgresses;
+  },
 );
 onMounted(async () => {
-    const progs = await controller.getLocalStorageProgresses();
-    progresses.value = progs;
+  const progs = await controller.getLocalStorageProgresses();
+  progresses.value = progs;
 });
 
 const progresses = ref<LocalStorageType["progresses"]>([]);
 //処理中かどうか、progressesの最終要素が"progress"かどうかで判断
 const isProcessing = computed(() => {
-    const last = progresses.value.at(-1);
-    if (!last) return false;
-    return last.type === "progress";
+  const last = progresses.value.at(-1);
+  if (!last) return false;
+  return last.type === "progress";
 });
 
 const onclick = async () => {
-    if (!isProcessing.value) {
-        await controller.fetchAndOutputData();
-    }
+  if (!isProcessing.value) {
+    await controller.fetchAndOutputData();
+  }
 };
 </script>

--- a/chrome-extension/tailwind.config.js
+++ b/chrome-extension/tailwind.config.js
@@ -1,8 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-    content: ["./src/**/*.{vue,js,ts,jsx,tsx}"],
-    theme: {
-        extend: {},
-    },
-    plugins: [],
+  content: ["./src/**/*.{vue,js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
 };

--- a/chrome-extension/tsconfig.json
+++ b/chrome-extension/tsconfig.json
@@ -1,27 +1,34 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "skipLibCheck": true,
+	"compilerOptions": {
+		"target": "ES2020",
+		"useDefineForClassFields": true,
+		"module": "ESNext",
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"skipLibCheck": true,
 
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "preserve",
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "preserve",
 
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
+		/* Linting */
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true,
 
-    "types": ["@vitest/browser/providers/playwright", "chrome"]
-  },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "vite-env.d.ts", "tests/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+		"types": ["@vitest/browser/providers/playwright", "chrome"]
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.d.ts",
+		"src/**/*.tsx",
+		"src/**/*.vue",
+		"vite-env.d.ts",
+		"tests/**/*.test.ts"
+	],
+	"references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/chrome-extension/tsconfig.node.json
+++ b/chrome-extension/tsconfig.node.json
@@ -1,10 +1,10 @@
 {
-  "compilerOptions": {
-    "composite": true,
-    "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
-  },
-  "include": ["vite.config.ts"]
+	"compilerOptions": {
+		"composite": true,
+		"skipLibCheck": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"allowSyntheticDefaultImports": true
+	},
+	"include": ["vite.config.ts"]
 }

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
 
               terraform
               google-cloud-sdk
+              tflint
             ];
             shellHook = ''
               echo "entered devShell"

--- a/gcp/.prettierignore
+++ b/gcp/.prettierignore
@@ -1,0 +1,4 @@
+.terraform/
+terraform.tfstate*
+.terraform.lock.hcl
+*.zip

--- a/gcp/.prettierrc
+++ b/gcp/.prettierrc
@@ -1,0 +1,20 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "overrides": [
+    {
+      "files": ["*.tf", "*.tfvars"],
+      "options": {
+        "parser": "hcl",
+        "printWidth": 80,
+        "tabWidth": 2
+      }
+    }
+  ]
+}

--- a/gcp/.tflint.hcl
+++ b/gcp/.tflint.hcl
@@ -1,0 +1,50 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "google" {
+  enabled = true
+  version = "0.31.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = true
+}
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+
+rule "terraform_deprecated_index" {
+  enabled = true
+}
+
+rule "terraform_deprecated_interpolation" {
+  enabled = true
+}
+
+rule "terraform_required_version" {
+  enabled = true
+}
+
+rule "terraform_required_providers" {
+  enabled = true
+}

--- a/gcp/biome.json
+++ b/gcp/biome.json
@@ -1,0 +1,35 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"includes": [
+			"**/*.json",
+			"!node_modules/",
+			"!.terraform/",
+			"!terraform.tfstate*"
+		]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"indentWidth": 2,
+		"lineWidth": 80,
+		"lineEnding": "lf"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"json": {
+		"formatter": {
+			"trailingCommas": "none"
+		}
+	}
+}

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -1,8 +1,26 @@
 terraform {
+  required_version = ">= 1.0"
+
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"
       version = "3.0.2"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
     }
   }
 }
@@ -26,10 +44,6 @@ provider "docker" {
   registry_auth {
     address = local.docker_host
   }
-}
-
-data "google_project" "project" {
-  project_id = var.project_id
 }
 
 resource "random_id" "random_suffix" {
@@ -226,5 +240,6 @@ resource "google_cloud_scheduler_job" "sheet_scraper_scheduler" {
 }
 
 output "suffix" {
-  value = local.suffix
+  description = "Environment suffix used for resource naming"
+  value       = local.suffix
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -8,11 +8,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = "~> 7.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 6.0"
+      version = "~> 7.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Summary
- gcp/ディレクトリにTFLint, Prettier, Biomeを導入
- chrome-extension/ディレクトリにPrettier, Biomeのlintチェックを導入
- GitHub Actionsでフォーマット・リントが成功した場合のみ後続ジョブを実行するように設定

## Changes
### gcp/ディレクトリ
- .tflint.hcl: TFLint設定ファイル（GCPプラグイン含む）
- .prettierrc: Prettier設定（Terraform用）
- .prettierignore: Prettierの除外設定
- biome.json: Biome設定（JSONファイル用）

### GitHub Actions
- .github/workflows/lint-chromeex/action.yaml: chrome-extension用のlintアクション
- .github/workflows/master-pr.yaml: 
  - chrome-extension-lintジョブを追加
  - gcp-lintジョブを追加
  - buildとtestジョブがlintに依存するように設定

### その他
- flake.nix: tflintパッケージを追加

## Test plan
- [ ] PRを作成してGitHub Actionsが実行されることを確認
- [ ] gcp/のリントエラーで後続ジョブが実行されないことを確認
- [ ] フォーマット・リント後に後続ジョブが実行されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **チョア**
  * CIにChrome拡張とGCP向けの自動リンティング/フォーマットチェックを追加し、ビルド/テストをリンター結果に連動させるようにしました
  * 開発環境にTerraform向けリンターを導入し、フォーマッタ/リンタの設定を追加しました

* **バグ修正**
  * ファイルパス検証の不正文字判定を改善しました

* **スタイル**
  * プロジェクト全体のコード・ドキュメント書式を一貫化しました (複数ファイルの整形・インデント統一)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->